### PR TITLE
No expire value raises error

### DIFF
--- a/redis_rw_lock/__init__.py
+++ b/redis_rw_lock/__init__.py
@@ -77,7 +77,8 @@ class _LightSwitch:
     def acquire(self, lock):
         self.__mutex.acquire()
         self.__redis_conn.incr(self.__counter_name)
-        self.__redis_conn.expire(self.__counter_name, self.__expire)
+        if self.__expire:
+            self.__redis_conn.expire(self.__counter_name, self.__expire)
         counter_value = int(self.__redis_conn.get(self.__counter_name))
         logging.debug('Counter {}: {}'.format(self.__counter_name, counter_value))
         if counter_value == 1:
@@ -87,7 +88,8 @@ class _LightSwitch:
     def release(self, lock):
         self.__mutex.acquire()
         self.__redis_conn.decr(self.__counter_name)
-        self.__redis_conn.expire(self.__counter_name, self.__expire)
+        if self.__expire:
+            self.__redis_conn.expire(self.__counter_name, self.__expire)
         counter_value = int(self.__redis_conn.get(self.__counter_name))
         logging.debug('Counter {}: {}'.format(self.__counter_name, counter_value))
         if counter_value == 0:

--- a/redis_rw_lock/__init__.py
+++ b/redis_rw_lock/__init__.py
@@ -14,15 +14,15 @@ class RWLock:
 
         self.__mode = mode
         self.__read_switch = _LightSwitch(
-            redis_conn, 'read_switch:{}'.format(name), expire=expire, auto_renew=auto_renew)
+            redis_conn, f'read_switch:{name}', expire=expire, auto_renew=auto_renew)
         self.__write_switch = _LightSwitch(
-            redis_conn, 'write_switch:{}'.format(name), expire=expire, auto_renew=auto_renew)
+            redis_conn, f'write_switch:{name}', expire=expire, auto_renew=auto_renew)
         self.__no_readers = redis_lock.Lock(
-            redis_conn, 'lock:no_readers:{}'.format(name), expire=expire, auto_renewal=auto_renew)
+            redis_conn, f'lock:no_readers:{name}', expire=expire, auto_renewal=auto_renew)
         self.__no_writers = redis_lock.Lock(
-            redis_conn, 'lock:no_writers:{}'.format(name), expire=expire, auto_renewal=auto_renew)
+            redis_conn, f'lock:no_writers:{name}', expire=expire, auto_renewal=auto_renew)
         self.__readers_queue = redis_lock.Lock(
-            redis_conn, 'lock:readers_queue:{}'.format(name), expire=expire, auto_renewal=auto_renew)
+            redis_conn, f'lock:readers_queue:{name}', expire=expire, auto_renewal=auto_renew)
 
     def __reader_acquire(self):
         self.__readers_queue.acquire()
@@ -64,15 +64,15 @@ class _LightSwitch:
     """An auxiliary "light switch"-like object. The first thread turns on the
     "switch", the last one turns it off."""
     def __init__(self, redis_conn, name, expire=None, auto_renew=False):
-        self.__counter_name = 'lock:switch:counter:{}'.format(name)
+        self.__counter_name = f'lock:switch:counter:{name}'
         self.__name = name
         self.__expire = expire
         self.__redis_conn = redis_conn
         self.__redis_conn.set(self.__counter_name, 0, nx=True, ex=self.__expire)
         counter_value = int(self.__redis_conn.get(self.__counter_name))
-        logging.debug('Counter - Initial Value - {}: {}'.format(self.__counter_name, counter_value))
+        logging.debug(f'Counter - Initial Value - {self.__counter_name}: {counter_value}')
         self.__mutex = redis_lock.Lock(
-            redis_conn, 'lock:switch:{}'.format(name), expire=expire, auto_renewal=auto_renew)
+            redis_conn, f'lock:switch:{name}', expire=expire, auto_renewal=auto_renew)
 
     def acquire(self, lock):
         self.__mutex.acquire()
@@ -80,7 +80,7 @@ class _LightSwitch:
         if self.__expire:
             self.__redis_conn.expire(self.__counter_name, self.__expire)
         counter_value = int(self.__redis_conn.get(self.__counter_name))
-        logging.debug('Counter {}: {}'.format(self.__counter_name, counter_value))
+        logging.debug(f'Counter {self.__counter_name}: {counter_value}')
         if counter_value == 1:
             lock.acquire()
         self.__mutex.release()
@@ -91,7 +91,7 @@ class _LightSwitch:
         if self.__expire:
             self.__redis_conn.expire(self.__counter_name, self.__expire)
         counter_value = int(self.__redis_conn.get(self.__counter_name))
-        logging.debug('Counter {}: {}'.format(self.__counter_name, counter_value))
+        logging.debug(f'Counter {self.__counter_name}: {counter_value}')
         if counter_value == 0:
             lock.reset()
         self.__mutex.release()


### PR DESCRIPTION
If no value is provided to the expire argument of the RWLock class, the acquire method raises an error.
This happens because the command `EXPIRE` doesn't accept the None value as argument.

On this PR I also replaced the str.format expressions by f-strings. I you don't agree with this last change I can revert it
```
>>> import redis
>>> redis_conn = redis.Redis()
>>> from redis_rw_lock import RWLock
>>> read_lock = RWLock(redis_conn, "some_name", RWLock.READ)
>>> read_lock.acquire()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/aspedrosa/.trash/test/venv/lib/python3.8/site-packages/redis_rw_lock/__init__.py", line 47, in acquire
    return self.__reader_acquire()
  File "/home/aspedrosa/.trash/test/venv/lib/python3.8/site-packages/redis_rw_lock/__init__.py", line 30, in __reader_acquire
    self.__read_switch.acquire(self.__no_writers)
  File "/home/aspedrosa/.trash/test/venv/lib/python3.8/site-packages/redis_rw_lock/__init__.py", line 81, in acquire
    self.__redis_conn.expire(self.__counter_name, self.__expire)
  File "/home/aspedrosa/.trash/test/venv/lib/python3.8/site-packages/redis/client.py", line 1591, in expire
    return self.execute_command('EXPIRE', name, time)
  File "/home/aspedrosa/.trash/test/venv/lib/python3.8/site-packages/redis/client.py", line 900, in execute_command
    conn.send_command(*args)
  File "/home/aspedrosa/.trash/test/venv/lib/python3.8/site-packages/redis/connection.py", line 725, in send_command
    self.send_packed_command(self.pack_command(*args),
  File "/home/aspedrosa/.trash/test/venv/lib/python3.8/site-packages/redis/connection.py", line 775, in pack_command
    for arg in imap(self.encoder.encode, args):
  File "/home/aspedrosa/.trash/test/venv/lib/python3.8/site-packages/redis/connection.py", line 119, in encode
    raise DataError("Invalid input of type: '%s'. Convert to a "
redis.exceptions.DataError: Invalid input of type: 'NoneType'. Convert to a bytes, string, int or float first.
```